### PR TITLE
build 0.1.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/0001-write-deps-from-missing-file.patch
+++ b/recipe/0001-write-deps-from-missing-file.patch
@@ -1,0 +1,11 @@
+--- setup.py	2023-12-06 19:43:46.236431069 +0100
++++ setup.py	2023-12-06 19:41:10.478374088 +0100
+@@ -21,7 +21,7 @@
+     platforms=["Windows", "POSIX", "MacOSX"],
+     license="MIT",
+     packages=find_packages(),
+-    install_requires=open("requirements.txt").read().splitlines(),
++    install_requires=['pyyaml', 'markdown', 'ordered-set', 'click'],
+     entry_points="""
+         [console_scripts]
+         mi=modelindex.__main__:cli

--- a/recipe/0002-make-proper-package.patch
+++ b/recipe/0002-make-proper-package.patch
@@ -5,7 +5,7 @@
      platforms=["Windows", "POSIX", "MacOSX"],
      license="MIT",
 -    packages=find_packages(),
-+    find_packages(include=['modelindex*']),
++    packages=find_packages(include=['modelindex*']),
      install_requires=['pyyaml', 'markdown', 'ordered-set', 'click'],
      entry_points="""
          [console_scripts]

--- a/recipe/0002-make-proper-package.patch
+++ b/recipe/0002-make-proper-package.patch
@@ -1,0 +1,11 @@
+--- setup.py	2023-12-08 12:57:31.487425099 +0100
++++ setup.py	2023-12-08 14:02:08.539366315 +0100
+@@ -20,7 +20,7 @@
+     url=url,
+     platforms=["Windows", "POSIX", "MacOSX"],
+     license="MIT",
+-    packages=find_packages(),
++    find_packages(include=['modelindex*']),
+     install_requires=['pyyaml', 'markdown', 'ordered-set', 'click'],
+     entry_points="""
+         [console_scripts]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,29 +7,24 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/model-index-{{ version }}.tar.gz
-    sha256: 2f9870200f3b00813881b07b90d2c67291663534e43915c75fe476b6977bf2ad
-  - url: https://raw.githubusercontent.com/paperswithcode/model-index/main/LICENSE
-    sha256: addec7ad58188c4d6df6f578fb0c6877bd799d787ecbd9f133213de995b345a4
-  - url: https://raw.githubusercontent.com/paperswithcode/model-index/main/requirements.txt
-    sha256: 8356928a01bcda562a9d2a8168997db018e4c803b43ad9c6d1e137f80ca95759
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
   entry_points:
     - mi = modelindex.__main__:cli
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - pyyaml
     - markdown
     - ordered-set
     - click
   run:
-    - python >=3.7
+    - python
     - pyyaml
     - markdown
     - ordered-set
@@ -46,8 +41,18 @@ test:
 about:
   home: https://github.com/paperswithcode/model-index
   summary: Create a source of truth for ML model results and browse it on Papers with Code
+  description: |
+    model-index has two goals:
+      * Make it easy to maintain a source-of-truth index of Machine Learning model metadata
+      * Enable the community browse this model metadata on Papers with Code
+    The main design principle of model-index is flexibility. You can store your model metadata however is the most
+    convenient for you - as JSONs, YAMLs or as annotations inside markdown. model-index provides a convenient way to
+    collect all this metadata into a single file that's browsable, searchable and comparable.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://github.com/paperswithcode/model-index
+  dev_url: https://github.com/paperswithcode/model-index
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ test:
     - modelindex
   commands:
     - pip check
+    - mi --help
     - cd github_repo
     - pytest -k "not ({{ tests_to_skip }})" tests
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
     sha256: 2f9870200f3b00813881b07b90d2c67291663534e43915c75fe476b6977bf2ad
     patches:
       - 0001-write-deps-from-missing-file.patch
-  - url: https://raw.githubusercontent.com/paperswithcode/model-index/main/LICENSE
-    sha256: addec7ad58188c4d6df6f578fb0c6877bd799d787ecbd9f133213de995b345a4
+      - 0002-make-proper-package.patch
   - git_url: https://github.com/paperswithcode/model-index
     git_rev: 09c7865ab2cbe00827d3af879a2faf7d286cb1b7
     folder: github_repo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,12 +31,16 @@ requirements:
     - click
 
 test:
+  source_files:
+    - tests
   imports:
     - modelindex
   commands:
     - pip check
+    - pytest tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/paperswithcode/model-index

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,3 +76,5 @@ about:
 extra:
   recipe-maintainers:
     - giswqs
+  skip-lints:
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ source:
     folder: github_repo
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
   entry_points:
@@ -27,6 +26,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
+    - git
   host:
     - python
     - pip
@@ -34,6 +34,8 @@ requirements:
     - markdown
     - ordered-set
     - click
+    - wheel
+    - setuptools
   run:
     - python
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ about:
     convenient for you - as JSONs, YAMLs or as annotations inside markdown. model-index provides a convenient way to
     collect all this metadata into a single file that's browsable, searchable and comparable.
   license: MIT
-  license_file: LICENSE
+  license_file: github_repo/LICENSE
   license_family: MIT
   doc_url: https://github.com/paperswithcode/model-index
   dev_url: https://github.com/paperswithcode/model-index

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/model-index-{{ version }}.tar.gz
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 2f9870200f3b00813881b07b90d2c67291663534e43915c75fe476b6977bf2ad
+    patches:
+      - 0001-write-deps-from-missing-file.patch
+  - url: https://raw.githubusercontent.com/paperswithcode/model-index/main/LICENSE
+    sha256: addec7ad58188c4d6df6f578fb0c6877bd799d787ecbd9f133213de995b345a4
+  - git_url: https://github.com/paperswithcode/model-index
+    git_rev: 09c7865ab2cbe00827d3af879a2faf7d286cb1b7
+    folder: github_repo
 
 build:
   noarch: python
@@ -16,6 +24,9 @@ build:
     - mi = modelindex.__main__:cli
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -32,12 +43,14 @@ requirements:
 
 test:
   source_files:
-    - tests
+    - github_repo/tests
   imports:
     - modelindex
   commands:
     - pip check
-    - pytest tests
+    # skipping one test because of missing test file
+    - cd github_repo
+    - pytest -k "not test_examples" tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,11 @@ requirements:
     - ordered-set
     - click
 
+# skipping one test because of missing test file
+{% set tests_to_skip = "test_examples" %}
+# skipping because windows paths mess with asserts
+{% set tests_to_skip = tests_to_skip + " or test_expand_wildcard_path or test_models_import_wildcard or test_results_check" %}  # [win]
+
 test:
   source_files:
     - github_repo/tests
@@ -50,9 +55,8 @@ test:
     - modelindex
   commands:
     - pip check
-    # skipping one test because of missing test file
     - cd github_repo
-    - pytest -k "not test_examples" tests
+    - pytest -k "not ({{ tests_to_skip }})" tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
-    - git
+    - git  # [not win]
   host:
     - python
     - pip


### PR DESCRIPTION
* [PKG-3570]
* [Upstream requirements](https://github.com/paperswithcode/model-index/blob/main/requirements.txt)

Notes:
* upstream project hierarchy is different between GH and PyPi --> using GH only for tests
* GH repo is untagged
* requirements were taken from GH because in PyPi tarball they're missing

[PKG-3570]: https://anaconda.atlassian.net/browse/PKG-3570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ